### PR TITLE
Add start times for each round at the tournament level

### DIFF
--- a/android/app/src/main/java/com/iqoid/pairgoth/InformationFragment.kt
+++ b/android/app/src/main/java/com/iqoid/pairgoth/InformationFragment.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.graphics.Typeface
@@ -39,6 +40,7 @@ class InformationFragment : Fragment() {
     private lateinit var tournamentGobanSize: TextView
     private lateinit var tournamentKomi: TextView
     private lateinit var timeSystemContainer: LinearLayout
+    private lateinit var startTimesContainer: LinearLayout
 
     private var tournamentId: String = "1"
 
@@ -73,6 +75,7 @@ class InformationFragment : Fragment() {
         tournamentGobanSize = view.findViewById(R.id.tournamentGobanSize)
         tournamentKomi = view.findViewById(R.id.tournamentKomi)
         timeSystemContainer = view.findViewById(R.id.timeSystemContainer)
+        startTimesContainer = view.findViewById(R.id.startTimesContainer)
 
         // Get the tournament ID from the arguments
         tournamentId = arguments?.getString(TOURNAMENT_ID_EXTRA)?: "1"
@@ -158,6 +161,9 @@ class InformationFragment : Fragment() {
                 addTextViewToLinearLayout(timeSystemContainer, formatLabelAndValue("Increment",toHMS(it)))
             }
         }
+
+        // Start Times
+        updateStartTimesUI(tournament.rounds, tournament.startTimes)
     }
 
     private fun addTextViewToLinearLayout(container: LinearLayout, text: SpannableString) {
@@ -222,5 +228,19 @@ class InformationFragment : Fragment() {
         val remainingSeconds = seconds % 60
 
         return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
+    }
+
+    private fun updateStartTimesUI(rounds: Int, startTimes: List<String>?) {
+        startTimesContainer.removeAllViews()
+        for (i in 1..rounds) {
+            val editText = EditText(context)
+            editText.hint = "Start Time for Round $i"
+            startTimes?.let {
+                if (i <= it.size) {
+                    editText.setText(it[i - 1])
+                }
+            }
+            startTimesContainer.addView(editText)
+        }
     }
 }

--- a/android/app/src/main/java/com/iqoid/pairgoth/client/model/Tournament.kt
+++ b/android/app/src/main/java/com/iqoid/pairgoth/client/model/Tournament.kt
@@ -4,5 +4,6 @@ import com.google.gson.annotations.SerializedName
 
 data class Tournament(
     @SerializedName("name") val name: String? = null,
-    @SerializedName("lastModified") val lastModified: String? = null
+    @SerializedName("lastModified") val lastModified: String? = null,
+    @SerializedName("startTimes") val startTimes: List<String>? = null
 )

--- a/android/app/src/main/java/com/iqoid/pairgoth/client/model/TournamentDetails.kt
+++ b/android/app/src/main/java/com/iqoid/pairgoth/client/model/TournamentDetails.kt
@@ -21,7 +21,8 @@ data class TournamentDetails(
     val rounds: Int,
     @SerializedName("pairing")
     val pairing: PairingDetails,
-    //Removed stats, teamSize and frozen because they are not used by the fragment
+    @SerializedName("startTimes")
+    val startTimes: List<String>?
 )
 
 data class TimeSystemDetails(

--- a/android/app/src/main/java/com/iqoid/pairgoth/client/network/PairGothApiService.kt
+++ b/android/app/src/main/java/com/iqoid/pairgoth/client/network/PairGothApiService.kt
@@ -44,4 +44,3 @@ interface PairGothApiService {
     @GET("tour/{tournamentId}/standings/{round}")
     suspend fun getStandings(@Path("tournamentId") tournamentId: String, @Path("round") round: Int): Response<List<Standing>>
 }
-

--- a/api-webapp/src/main/kotlin/org/jeudego/pairgoth/api/TournamentHandler.kt
+++ b/api-webapp/src/main/kotlin/org/jeudego/pairgoth/api/TournamentHandler.kt
@@ -37,6 +37,7 @@ object TournamentHandler: PairgothApiHandler {
                                     json["stats"] = tour.stats()
                                     json["teamSize"] = tour.type.playersNumber
                                     json["frozen"] = tour.frozen != null
+                                    json["startTimes"] = tour.startTimes?.toJsonArray()
                                 }
                             }
                         } ?: badRequest("no tournament with id #${id}")

--- a/api-webapp/src/main/kotlin/org/jeudego/pairgoth/model/Tournament.kt
+++ b/api-webapp/src/main/kotlin/org/jeudego/pairgoth/model/Tournament.kt
@@ -31,7 +31,8 @@ sealed class Tournament <P: Pairable>(
     val rules: Rules = Rules.FRENCH,
     val gobanSize: Int = 19,
     val komi: Double = 7.5,
-    val tablesExclusion: MutableList<String> = mutableListOf()
+    val tablesExclusion: MutableList<String> = mutableListOf(),
+    val startTimes: MutableList<String>? = null
 ) {
     companion object {}
     enum class Type(val playersNumber: Int, val individual: Boolean = true) {
@@ -207,8 +208,9 @@ class StandardTournament(
     rules: Rules = Rules.FRENCH,
     gobanSize: Int = 19,
     komi: Double = 7.5,
-    tablesExclusion: MutableList<String> = mutableListOf()
-): Tournament<Player>(id, type, name, shortName, startDate, endDate, director, country, location, online, timeSystem, rounds, pairing, rules, gobanSize, komi, tablesExclusion) {
+    tablesExclusion: MutableList<String> = mutableListOf(),
+    startTimes: MutableList<String>? = null
+): Tournament<Player>(id, type, name, shortName, startDate, endDate, director, country, location, online, timeSystem, rounds, pairing, rules, gobanSize, komi, tablesExclusion, startTimes) {
     override val players get() = _pairables
 }
 
@@ -230,8 +232,9 @@ class TeamTournament(
     rules: Rules = Rules.FRENCH,
     gobanSize: Int = 19,
     komi: Double = 7.5,
-    tablesExclusion: MutableList<String> = mutableListOf()
-): Tournament<TeamTournament.Team>(id, type, name, shortName, startDate, endDate, director, country, location, online, timeSystem, rounds, pairing, rules, gobanSize, komi, tablesExclusion) {
+    tablesExclusion: MutableList<String> = mutableListOf(),
+    startTimes: MutableList<String>? = null
+): Tournament<TeamTournament.Team>(id, type, name, shortName, startDate, endDate, director, country, location, online, timeSystem, rounds, pairing, rules, gobanSize, komi, tablesExclusion, startTimes) {
     companion object {
         private val epsilon = 0.0001
     }
@@ -306,7 +309,8 @@ fun Tournament.Companion.fromJson(json: Json.Object, default: Tournament<*>? = n
                 timeSystem = json.getObject("timeSystem")?.let { TimeSystem.fromJson(it) } ?: default?.timeSystem ?: badRequest("missing timeSystem"),
                 rounds = json.getInt("rounds") ?: default?.rounds ?: badRequest("missing rounds"),
                 pairing = json.getObject("pairing")?.let { Pairing.fromJson(it, default?.pairing) } ?: default?.pairing ?: badRequest("missing pairing"),
-                tablesExclusion = json.getArray("tablesExclusion")?.map { item -> item as String }?.toMutableList() ?: default?.tablesExclusion ?: mutableListOf()
+                tablesExclusion = json.getArray("tablesExclusion")?.map { item -> item as String }?.toMutableList() ?: default?.tablesExclusion ?: mutableListOf(),
+                startTimes = json.getArray("startTimes")?.map { item -> item as String }?.toMutableList() ?: default?.startTimes ?: mutableListOf()
             )
         else
             TeamTournament(
@@ -326,7 +330,8 @@ fun Tournament.Companion.fromJson(json: Json.Object, default: Tournament<*>? = n
                 timeSystem = json.getObject("timeSystem")?.let { TimeSystem.fromJson(it) } ?: default?.timeSystem ?: badRequest("missing timeSystem"),
                 rounds = json.getInt("rounds") ?: default?.rounds ?: badRequest("missing rounds"),
                 pairing = json.getObject("pairing")?.let { Pairing.fromJson(it, default?.pairing) } ?: default?.pairing ?: badRequest("missing pairing"),
-                tablesExclusion = json.getArray("tablesExclusion")?.map { item -> item as String }?.toMutableList() ?: default?.tablesExclusion ?: mutableListOf()
+                tablesExclusion = json.getArray("tablesExclusion")?.map { item -> item as String }?.toMutableList() ?: default?.tablesExclusion ?: mutableListOf(),
+                startTimes = json.getArray("startTimes")?.map { item -> item as String }?.toMutableList() ?: default?.startTimes ?: mutableListOf()
             )
     json.getArray("players")?.forEach { obj ->
         val pairable = obj as Json.Object
@@ -377,6 +382,9 @@ fun Tournament<*>.toJson() = Json.MutableObject(
     if (frozen != null) {
         tour["frozen"] = frozen
     }
+    if (startTimes != null) {
+        tour["startTimes"] = startTimes.toJsonArray()
+    }
 }
 
 fun Tournament<*>.toFullJson(): Json.Object {
@@ -391,6 +399,9 @@ fun Tournament<*>.toFullJson(): Json.Object {
     }
     if (frozen != null) {
         json["frozen"] = frozen
+    }
+    if (startTimes != null) {
+        json["startTimes"] = startTimes.toJsonArray()
     }
     return json
 }

--- a/view-webapp/src/main/webapp/js/tour-information.inc.js
+++ b/view-webapp/src/main/webapp/js/tour-information.inc.js
@@ -7,6 +7,14 @@ function autofillShortName(dt, loc) {
   }
 }
 
+function updateStartTimesUI(rounds) {
+  const startTimesContainer = $('#startTimesContainer');
+  startTimesContainer.empty();
+  for (let i = 0; i < rounds; i++) {
+    startTimesContainer.append(`<input type="text" name="startTime" placeholder="Start time for round ${i + 1}" />`);
+  }
+}
+
 onLoad(() => {
   $('#edit').on('click', e => {
     e.preventDefault();
@@ -286,4 +294,11 @@ onLoad(() => {
     if (pairing === 'swiss') $('#tournament-infos .swiss').removeClass('hidden');
     else $('#tournament-infos .swiss').addClass('hidden');
   });
+
+  const roundsInput = $('input[name="rounds"]');
+  roundsInput.on('change', e => {
+    updateStartTimesUI(e.target.value);
+  });
+
+  updateStartTimesUI(roundsInput.val());
 });

--- a/view-webapp/src/main/webapp/tour-information.inc.html
+++ b/view-webapp/src/main/webapp/tour-information.inc.html
@@ -217,6 +217,21 @@
         </div>
       </div>
     </div>
+    <div class="roundbox">
+      <div class="three stackable fields">
+        <div class="seven wide field">
+          <label>Start times</label>
+          <span class="info"></span>
+          <div id="startTimesContainer">
+            #if($tour)
+              #foreach($startTime in $tour.startTimes)
+                <input type="text" name="startTime" placeholder="Start time for round" value="$startTime"/>
+              #end
+            #end
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="form-actions">
       <button id="cancel" class="ui gray right labeled icon floating edit button">
         <i class="times icon"></i>


### PR DESCRIPTION
Add start times for each round at the tournament level and make this information available in the API.

* Add `startTimes` property to `Tournament` and `TournamentDetails` data classes in `android/app/src/main/java/com/iqoid/pairgoth/client/model/Tournament.kt` and `TournamentDetails.kt`.
* Add `updateStartTimesUI` method in `InformationFragment.kt` to dynamically update the start times input fields based on the number of rounds.
* Update `get` method in `TournamentHandler.kt` to include `startTimes` field in the response.
* Add `startTimes` property to `Tournament` class in `api-webapp/src/main/kotlin/org/jeudego/pairgoth/model/Tournament.kt`.
* Add a new section "Start times" in `tour-information.inc.html` with input fields for each round.
* Add `updateStartTimesUI` function in `tour-information.inc.js` to dynamically update the start times input fields based on the number of rounds.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lgiulian/pairgoth?shareId=XXXX-XXXX-XXXX-XXXX).