### PR TITLE
Update base URL for API in TournamentActivity

### DIFF
--- a/android/app/src/main/java/com/iqoid/pairgoth/client/network/NetworkManager.kt
+++ b/android/app/src/main/java/com/iqoid/pairgoth/client/network/NetworkManager.kt
@@ -1,5 +1,7 @@
 package com.iqoid.pairgoth.client.network
 
+import android.content.Context
+import android.preference.PreferenceManager
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
@@ -8,34 +10,65 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object NetworkManager {
-    private const val BASE_URL = "http://192.168.0.138:8080/api/" // Replace with your API's base URL
+    private var baseUrl: String = "http://192.168.0.138:8080/api/"
 
-    val pairGothApiService: PairGothApiService by lazy {
-        val loggingInterceptor = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY //optional logging
+    @Volatile
+    private var retrofit: Retrofit? = null
+
+    @Volatile
+    private var pairGothApiServiceInstance: PairGothApiService? = null
+
+    private val lock = Any()
+
+    val pairGothApiService: PairGothApiService
+        get() {
+            return pairGothApiServiceInstance ?: synchronized(lock) {
+                pairGothApiServiceInstance ?: createRetrofitClient().also {
+                    pairGothApiServiceInstance = it
+                }
+            }
         }
 
-        // Create an interceptor to add the Accept header
+    private fun createRetrofitClient(): PairGothApiService {
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
         val acceptHeaderInterceptor = object : Interceptor {
             override fun intercept(chain: Interceptor.Chain): Response {
                 val request = chain.request().newBuilder()
-                    .addHeader("Accept", "application/json") // Add the Accept header
+                    .addHeader("Accept", "application/json")
                     .build()
                 return chain.proceed(request)
             }
         }
 
         val client = OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor) //optional logging
-            .addInterceptor(acceptHeaderInterceptor) // Add the Accept header interceptor
+            .addInterceptor(loggingInterceptor)
+            .addInterceptor(acceptHeaderInterceptor)
             .build()
 
-        val retrofit = Retrofit.Builder()
-            .baseUrl(BASE_URL)
+        retrofit = Retrofit.Builder()
+            .baseUrl(baseUrl)
             .client(client)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
 
-        retrofit.create(PairGothApiService::class.java)
+        return retrofit!!.create(PairGothApiService::class.java)
+    }
+
+    fun updateBaseUrl(newBaseUrl: String) {
+        synchronized(lock) {
+            baseUrl = newBaseUrl
+            pairGothApiServiceInstance = createRetrofitClient()
+        }
+    }
+
+    fun initializeBaseUrl(context: Context) {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val savedBaseUrl = sharedPreferences.getString("api-base-url", null)
+        if (savedBaseUrl != null) {
+            baseUrl = savedBaseUrl
+        }
     }
 }


### PR DESCRIPTION
Add functionality to update the Retrofit client with a new base URL after scanning a QR code and saving it in the app preferences.

* Modify `NetworkManager.kt` to include methods for updating the base URL and recreating the Retrofit client.
* Add logic in `TournamentActivity.kt` to scan a QR code, save the base URL in the app preferences, and update the Retrofit client with the new base URL.
* Initialize the base URL from shared preferences in `TournamentActivity.kt` and `NetworkManager.kt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lgiulian/pairgoth?shareId=XXXX-XXXX-XXXX-XXXX).